### PR TITLE
Incorrect IPAddress comparison

### DIFF
--- a/Lidgren.Network/NetPeer.LatencySimulation.cs
+++ b/Lidgren.Network/NetPeer.LatencySimulation.cs
@@ -283,7 +283,7 @@ namespace Lidgren.Network
 			{
 				// TODO: refactor this check outta here
 				ba = NetUtility.GetCachedBroadcastAddress();
-				if (Equals(target.Address, ba))
+				if (target.Address.Equals(ba))
 					m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
 
 				int bytesSent = m_socket.SendTo(m_sendBuffer, 0, numBytes, SocketFlags.None, target);

--- a/Lidgren.Network/NetPeer.LatencySimulation.cs
+++ b/Lidgren.Network/NetPeer.LatencySimulation.cs
@@ -283,7 +283,7 @@ namespace Lidgren.Network
 			{
 				// TODO: refactor this check outta here
 				ba = NetUtility.GetCachedBroadcastAddress();
-				if (target.Address == ba)
+				if (Equals(target.Address, ba))
 					m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
 
 				int bytesSent = m_socket.SendTo(m_sendBuffer, 0, numBytes, SocketFlags.None, target);


### PR DESCRIPTION
Hey there!

I've spotted an incorrect IPAddress comparison in NetPeer.ActuallySendPacket - Equals() should be used instead as there isn't an == overload. Apologies for the line-ending correction fluff around the actual change too.